### PR TITLE
[W9][v1.2] Create new "email" command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EmailCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EmailCommand.java
@@ -1,0 +1,55 @@
+package seedu.address.logic.commands;
+
+import java.util.List;
+import java.util.Objects;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.person.Person;
+
+/**
+ * Send an email to the person identified using it's last displayed index from the address book.
+ */
+public class EmailCommand extends Command {
+
+    public static final String COMMAND_WORD = "email";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Send an email to the person identified by the index number used in the last person listing.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " 1";
+
+    public static final String MESSAGE_EMAIL_PERSON_SUCCESS = "Drafting email to: %1$s";
+
+    private final Index targetIndex;
+
+    private Person personToEmail;
+
+    public EmailCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute() throws CommandException {
+
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        personToEmail = lastShownList.get(targetIndex.getZeroBased());
+
+        return new CommandResult(String.format(MESSAGE_EMAIL_PERSON_SUCCESS, personToEmail.getEmail()));
+
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof EmailCommand // instanceof handles nulls
+                && this.targetIndex.equals(((EmailCommand) other).targetIndex) // state check
+                && Objects.equals(this.personToEmail, ((EmailCommand) other).personToEmail));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.ClearHistoryCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EmailCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -88,8 +89,13 @@ public class AddressBookParser {
 
         case RedoCommand.COMMAND_WORD:
             return new RedoCommand();
+
         case LinkedInCommand.COMMAND_WORD:
             return new LinkedInCommandParser().parse(arguments);
+
+        case EmailCommand.COMMAND_WORD:
+            return new EmailCommandParser().parse(arguments);
+
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }

--- a/src/main/java/seedu/address/logic/parser/CommandList.java
+++ b/src/main/java/seedu/address/logic/parser/CommandList.java
@@ -7,6 +7,7 @@ import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.ClearHistoryCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EmailCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -33,6 +34,7 @@ public class CommandList {
         commandList.add(ClearHistoryCommand.COMMAND_WORD);
         commandList.add(DeleteCommand.COMMAND_WORD);
         commandList.add(EditCommand.COMMAND_WORD);
+        commandList.add(EmailCommand.COMMAND_WORD);
         commandList.add(ExitCommand.COMMAND_WORD);
         commandList.add(FindCommand.COMMAND_WORD);
         commandList.add(HelpCommand.COMMAND_WORD);

--- a/src/main/java/seedu/address/logic/parser/EmailCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EmailCommandParser.java
@@ -1,0 +1,29 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.logic.commands.EmailCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EmailCommand object
+ */
+public class EmailCommandParser implements Parser<EmailCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the EmailCommand
+     * and returns an EmailCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public EmailCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new EmailCommand(index);
+        } catch (IllegalValueException ive) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, EmailCommand.MESSAGE_USAGE));
+        }
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/EmailCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EmailCommandTest.java
@@ -1,0 +1,141 @@
+package seedu.address.logic.commands;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.CommandHistory;
+import seedu.address.logic.UndoRedoStack;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.ui.testutil.EventsCollectorRule;
+
+public class EmailCommandTest {
+
+    @Rule
+    public final EventsCollectorRule eventsCollectorRule = new EventsCollectorRule();
+
+    private Model model;
+
+    @Before
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Index lastPersonIndex = Index.fromOneBased(model.getFilteredPersonList().size());
+
+        assertExecutionSuccess(INDEX_FIRST_PERSON);
+        assertExecutionSuccess(INDEX_THIRD_PERSON);
+        assertExecutionSuccess(lastPersonIndex);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_failure() {
+        Index outOfBoundsIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+
+        assertExecutionFailure(outOfBoundsIndex, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        assertExecutionSuccess(INDEX_FIRST_PERSON);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_failure() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Index outOfBoundsIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundsIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        assertExecutionFailure(outOfBoundsIndex, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    /**
+     * Executes a {@code EmailCommand} with the given {@code index} and check that email address is shown correctly.
+     */
+    private void assertExecutionSuccess(Index index) {
+        EmailCommand emailCommand = prepareCommand(index);
+
+        List<Person> lastShownList = model.getFilteredPersonList();
+        Person personToEmail = lastShownList.get(index.getZeroBased());
+
+        try {
+            CommandResult commandResult = emailCommand.execute();
+            assertEquals(String.format(EmailCommand.MESSAGE_EMAIL_PERSON_SUCCESS, personToEmail.getEmail()),
+                    commandResult.feedbackToUser);
+        } catch (CommandException ce) {
+            throw new IllegalArgumentException("Execution of command should not fail.", ce);
+        }
+
+    }
+
+    /**
+     * Executes a {@code EmailCommand} with the given {@code index}, and checks that a {@code CommandException}
+     * is thrown with the {@code expectedMessage}.
+     */
+    private void assertExecutionFailure(Index index, String expectedMessage) {
+        EmailCommand emailCommand = prepareCommand(index);
+
+        try {
+            emailCommand.execute();
+            fail("The expected CommandException was not thrown.");
+        } catch (CommandException ce) {
+            assertEquals(expectedMessage, ce.getMessage());
+            assertTrue(eventsCollectorRule.eventsCollector.isEmpty());
+        }
+    }
+
+    @Test
+    public void equals() {
+        EmailCommand emailFirstCommand = new EmailCommand(INDEX_FIRST_PERSON);
+        EmailCommand emailSecondCommand = new EmailCommand(INDEX_SECOND_PERSON);
+
+        // same object -> returns true
+        assertTrue(emailFirstCommand.equals(emailFirstCommand));
+
+        // same values -> returns true
+        EmailCommand emailFirstCommandCopy = new EmailCommand(INDEX_FIRST_PERSON);
+        assertTrue(emailFirstCommand.equals(emailFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(emailFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(emailFirstCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(emailFirstCommand.equals(emailSecondCommand));
+    }
+
+    /**
+     * Returns a {@code EmailCommand} with parameters {@code index}.
+     */
+    private EmailCommand prepareCommand(Index index) {
+        EmailCommand emailCommand = new EmailCommand(index);
+        emailCommand.setData(model, new CommandHistory(), new UndoRedoStack());
+        return emailCommand;
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -21,6 +21,7 @@ import seedu.address.logic.commands.ClearHistoryCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.EmailCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
@@ -131,6 +132,12 @@ public class AddressBookParserTest {
         assertEquals(new LinkedInCommand(INDEX_FIRST_PERSON), command);
     }
 
+    @Test
+    public void parseCommand_email() throws Exception {
+        EmailCommand command = (EmailCommand) parser.parseCommand(
+                EmailCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new EmailCommand(INDEX_FIRST_PERSON), command);
+    }
 
     @Test
     public void parseCommand_redoCommandWord_returnsRedoCommand() throws Exception {

--- a/src/test/java/seedu/address/logic/parser/EmailCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EmailCommandParserTest.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.Test;
+
+import seedu.address.logic.commands.EmailCommand;
+
+/**
+ * As we are only doing white-box testing, our test cases do not cover path variations
+ * outside of the EmailCommand code. For example, inputs "1" and "1 abc" take the
+ * same path through the EmailCommand, and therefore we test only one of them.
+ * The path variation for those two cases occur inside the ParserUtil, and
+ * therefore should be covered by the ParserUtilTest.
+ */
+public class EmailCommandParserTest {
+
+    private EmailCommandParser parser = new EmailCommandParser();
+
+    @Test
+    public void parse_validArgs_returnsEmailCommand() {
+        assertParseSuccess(parser, "1", new EmailCommand(INDEX_FIRST_PERSON));
+    }
+
+    @Test
+    public void parse_invalidArgs_throwsParseException() {
+        assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, EmailCommand.MESSAGE_USAGE));
+    }
+}


### PR DESCRIPTION
Closes #72 

- Created new "email" command which takes in the email of a selected contact.
- Created tests for email command and the email command parser.